### PR TITLE
Removed unnecessary call to non-existing function sess_create()

### DIFF
--- a/SimpleLoginSecure.php
+++ b/SimpleLoginSecure.php
@@ -173,9 +173,6 @@ class SimpleLoginSecure
 
 			//Destroy old session
 			$this->CI->session->sess_destroy();
-			
-			//Create a fresh, brand new session
-			$this->CI->session->sess_create();
 
 			$this->CI->db->simple_query('UPDATE ' . $this->user_table  . ' SET user_last_login = NOW() WHERE user_id = ' . $user_data['user_id']);
 


### PR DESCRIPTION
The `sess_create()` function is no longer present in modern versions of CI, and so this call has to be removed in order for the library to work.
