### PR TITLE
Replaced NOW() with non-mysql-compatible PHP alternative.

### DIFF
--- a/SimpleLoginSecure.php
+++ b/SimpleLoginSecure.php
@@ -177,7 +177,7 @@ class SimpleLoginSecure
 			//Create a fresh, brand new session
 			$this->CI->session->sess_create();
 
-			$this->CI->db->simple_query('UPDATE ' . $this->user_table  . ' SET user_last_login = NOW() WHERE user_id = ' . $user_data['user_id']);
+			$this->CI->db->simple_query('UPDATE ' . $this->user_table  . ' SET user_last_login = "' . date('c') . '" WHERE user_id = ' . $user_data['user_id']);
 
 			//Set session data
 			unset($user_data['user_pass']);


### PR DESCRIPTION
Not all databases support `NOW()` (such as SQLite). `date()` is a safer way to add the date to the database. Plus, it's consistent with what is used in the other queries in the library.
